### PR TITLE
feat(ColorPicker): add ability to hide result

### DIFF
--- a/app/components/Ui/ColorPicker/Controls.vue
+++ b/app/components/Ui/ColorPicker/Controls.vue
@@ -1,6 +1,7 @@
 <template>
   <div data-slot="color-picker-controls" class="mt-3 flex items-center gap-2">
     <div
+      v-if="ctx.showResult.value"
       class="h-9 w-12 shrink-0 rounded-md shadow-xs ring-1 ring-border/40"
       :style="previewStyle"
     />

--- a/app/components/Ui/ColorPicker/Root.vue
+++ b/app/components/Ui/ColorPicker/Root.vue
@@ -21,6 +21,7 @@
       showFormatToggle?: boolean;
       showInput?: boolean;
       showPresets?: boolean;
+      showResult?: boolean;
       presets?: string[];
       class?: HTMLAttributes["class"];
     }>(),
@@ -31,6 +32,7 @@
       showFormatToggle: true,
       showInput: true,
       showPresets: false,
+      showResult: true;
       presets: () => [],
     }
   );
@@ -66,6 +68,7 @@
   const showFormatToggle = computed(() => !!props.showFormatToggle);
   const showInput = computed(() => !!props.showInput);
   const showPresets = computed(() => !!props.showPresets);
+  const showResult = computed(() => !!props.showResult);
   const presets = computed(() => props.presets ?? []);
 
   const currentColor = computed<Colord>(() => {
@@ -178,6 +181,7 @@
     showFormatToggle,
     showInput,
     showPresets,
+    showResult,
     presets,
 
     currentColor,

--- a/app/utils/color-picker.context.ts
+++ b/app/utils/color-picker.context.ts
@@ -16,6 +16,7 @@ export type ColorPickerContext = {
   showFormatToggle: ComputedRef<boolean>;
   showInput: ComputedRef<boolean>;
   showPresets: ComputedRef<boolean>;
+  showResult: ComputedRef<boolean>;
   presets: ComputedRef<string[]>;
 
   // computed


### PR DESCRIPTION
Added the ability to hide the result of the color picker via the `showResult` prop.

<img width="432" height="251" alt="image" src="https://github.com/user-attachments/assets/c7f61c86-d01c-431d-9f31-f023de9c5cc6" />
