### PR TITLE
Fix/tablet button overflow

### DIFF
--- a/app/components/Ui/InputGroup/Addon.vue
+++ b/app/components/Ui/InputGroup/Addon.vue
@@ -27,7 +27,7 @@
         "block-start":
           "order-first w-full justify-start px-3 pt-3 group-has-[>input]/input-group:pt-2.5 [.border-b]:pb-3",
         "block-end":
-          "order-last w-full justify-start px-3 pb-3 group-has-[>input]/input-group:pb-2.5 [.border-t]:pt-3",
+          "order-last w-full justify-start px-3 pb-3 group-has-[>input]/input-group:pb-2.5 [.border-t]:pt-3 flex-wrap gap-y-2",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
```markdown
## Problem

On tablet viewports (768-1024px), the send button in `UiInputGroupAddon` with `align="block-end"` overflows outside the container when "Agent Mode" is selected. The issue occurs because buttons are forced into a single row without wrapping.

**Affected:** Notion Prompt component and any InputGroup using `block-end` alignment with multiple buttons.

## Solution

Added `flex-wrap gap-y-2` to the `block-end` variant in `app/components/Ui/InputGroup/Addon.vue` (line 29) to allow buttons to wrap gracefully on narrower screens.

**Change:**
```diff
"block-end":
- "order-last w-full justify-start px-3 pb-3 group-has-[>input]/input-group:pb-2.5 [.border-t]:pt-3",
+ "order-last w-full justify-start px-3 pb-3 group-has-[>input]/input-group:pb-2.5 [.border-t]:pt-3 flex-wrap gap-y-2",
```

## Result

- **Desktop:** No change (buttons in single row)
- **Tablet:** Buttons wrap when needed, no overflow
- **Mobile:** Buttons wrap naturally
- **Other components:** Unaffected

Single file change, no breaking changes.